### PR TITLE
HDA-32 JWT 토큰 통신 및 저장 완료

### DIFF
--- a/Android/FitIn_v1/app/build.gradle
+++ b/Android/FitIn_v1/app/build.gradle
@@ -43,5 +43,6 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
 }

--- a/Android/FitIn_v1/app/src/main/AndroidManifest.xml
+++ b/Android/FitIn_v1/app/src/main/AndroidManifest.xml
@@ -2,39 +2,65 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.fitin_v1">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:usesCleartextTraffic="true"
+        android:name="com.example.fitin_v1.MyApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.FitIn_v1">
+        android:theme="@style/Theme.FitIn_v1"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".HomeActivity"
+            android:exported="false" />
         <activity
             android:name=".ui.splash.SplashActivity"
-            android:theme="@style/SplashScreenStyle"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/SplashScreenStyle">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ui.main.MainActivity" android:label="메인화면"/>
-        <activity android:name=".ui.login.LoginActivity" android:label="로그인"/>
-        <activity android:name=".ui.register.RegisterFirstActivity" android:label="회원가입"/>
-        <activity android:name=".ui.register.RegisterSecondActivity" android:label="회원가입2"/>
-        <activity android:name=".WebviewActivity" android:label="웹뷰"/>
-        <activity android:name=".ui.complete.CompleteActivity" android:label="완료"/>
-        <activity android:name=".ui.findid.FindIdActivity" android:label="아이디 찾기"/>
-        <activity android:name=".ui.findpw.FindPwFirstActivity" android:label="비밀번호 찾기"/>
-        <activity android:name=".ui.findpw.FindPwSecondActivity" android:label="비밀번호 찾기"/>
-        <activity android:name=".ui.findid.FindIdCompleteActivity" android:label="아이디 찾기 완료"/>
-        <activity android:name=".ui.findpw.FindPwCompleteActivity" android:label="비밀번호 찾기 완료"/>
-
+        <activity
+            android:name=".ui.main.MainActivity"
+            android:label="메인화면" />
+        <activity
+            android:name=".ui.login.LoginActivity"
+            android:label="로그인" />
+        <activity
+            android:name=".ui.register.RegisterFirstActivity"
+            android:label="회원가입" />
+        <activity
+            android:name=".ui.register.RegisterSecondActivity"
+            android:label="회원가입2" />
+        <activity
+            android:name=".WebviewActivity"
+            android:label="웹뷰" />
+        <activity
+            android:name=".ui.complete.CompleteActivity"
+            android:label="완료" />
+        <activity
+            android:name=".ui.findid.FindIdActivity"
+            android:label="아이디 찾기" />
+        <activity
+            android:name=".ui.findpw.FindPwFirstActivity"
+            android:label="비밀번호 찾기" />
+        <activity
+            android:name=".ui.findpw.FindPwSecondActivity"
+            android:label="비밀번호 찾기" />
+        <activity
+            android:name=".ui.findid.FindIdCompleteActivity"
+            android:label="아이디 찾기 완료" />
+        <activity
+            android:name=".ui.findpw.FindPwCompleteActivity"
+            android:label="비밀번호 찾기 완료" />
     </application>
-    <uses-permission android:name="android.permission.INTERNET"/>
+
 
 </manifest>

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/HomeActivity.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/HomeActivity.java
@@ -1,0 +1,109 @@
+package com.example.fitin_v1;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+
+import com.example.fitin_v1.Util.Utils;
+import com.example.fitin_v1.databinding.ActivityHomeBinding;
+import com.example.fitin_v1.dto.AccountResponseDto;
+import com.example.fitin_v1.dto.TokenDto;
+import com.example.fitin_v1.dto.TokenRequestDto;
+import com.example.fitin_v1.remote.api.GetAccount;
+import com.example.fitin_v1.remote.api.ReIssue;
+import com.example.fitin_v1.remote.singleton.RetrofitBuilder;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class HomeActivity extends AppCompatActivity {
+
+    private ActivityHomeBinding binding;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityHomeBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        ReIssue reIssue = RetrofitBuilder.getRetrofit().create(ReIssue.class);
+        GetAccount getAccount = RetrofitBuilder.getRetrofit().create(GetAccount.class);
+
+        Utils.init(getApplicationContext());
+
+//        // 서버와 POST 통신에는 문제 없음, 단지 직접 불러와서 출력하는데 있어서 살짝의 차이가 발생하는 것 같음
+//        // 어차피 SharedPreferences 작업은 백그라운드 작업이므로 문제 없음
+
+        binding.btnReissue.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // SharedPreferences로 불러오는 시점 중요함, 재발급하는 상황에서 불러와서 처리해줘야함
+                String at = Utils.getAccessToken("none");
+                String rt = Utils.getRefreshToken("nein");
+                TokenRequestDto tokenRequest = new TokenRequestDto(at,rt);
+                Call<TokenDto> call = reIssue.getReIssue(tokenRequest);
+                call.enqueue(new Callback<TokenDto>() {
+                    @Override
+                    public void onResponse(Call<TokenDto> call, Response<TokenDto> response) {
+                        if (!response.isSuccessful()) {
+                            Log.e("연결이 비정상적 : ", "error code : " + response.code());
+                        } else {
+                            Utils.setAccessToken(response.body().getAccessToken());
+                            Utils.setRefreshToken(response.body().getRefreshToken());
+//                            Log.e("액세스 토큰", "at : " + Utils.getAccessToken("nein"));
+//                            Log.e("리프레쉬 토큰", "rt : " + Utils.getRefreshToken("none"));
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<TokenDto> call, Throwable t) {
+
+                    }
+                });
+            }
+        });
+
+        binding.btnLogout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Utils.clearToken();
+//                Log.e("AT","Is it clear?"+Utils.getAccessToken("non"));
+            }
+        });
+
+        binding.btnGetinfo.setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View view) {
+                Call<AccountResponseDto> call = getAccount.getEmail("Bearer "+Utils.getAccessToken("nein"));
+//                Log.e("Call get:","At:"+Utils.getAccessToken("ein"));
+                call.enqueue(new Callback<AccountResponseDto>() {
+                    @Override
+                    public void onResponse(Call<AccountResponseDto> call, Response<AccountResponseDto> response) {
+                        if (!response.isSuccessful()) {
+//                            Log.e("연결이 비정상적 : ", "error code : " + response.code());
+//                            Log.e("Not renewal", "At:"+Utils.getAccessToken("nein"));
+                        } else {
+//                            Log.e("At", "At:"+Utils.getAccessToken("nein"));
+                            binding.tvEmail.setText(response.body().getEmail());
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<AccountResponseDto> call, Throwable t) {
+
+                    }
+                });
+            }
+        });
+
+        binding.btnClear.setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View view) {
+                binding.tvEmail.setText(" ");
+            }
+        });
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/MyApp.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/MyApp.java
@@ -1,0 +1,23 @@
+package com.example.fitin_v1;
+
+import android.app.Application;
+import android.content.Context;
+
+public class MyApp extends Application {
+    private static MyApp instance;
+
+    public static MyApp getInstance() {
+        return instance;
+    }
+
+    public static Context getContext(){
+        return instance;
+    }
+
+    @Override
+    public void onCreate() {
+        instance = this;
+        super.onCreate();
+    }
+
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/Util/AuthInterceptor.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/Util/AuthInterceptor.java
@@ -1,0 +1,54 @@
+package com.example.fitin_v1.Util;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.example.fitin_v1.MyApp;
+import com.example.fitin_v1.dto.TokenDto;
+import com.example.fitin_v1.dto.TokenRequestDto;
+import com.example.fitin_v1.remote.api.ReIssue;
+import com.example.fitin_v1.remote.singleton.RetrofitBuilder;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class AuthInterceptor implements Interceptor {
+
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        ReIssue reIssue = RetrofitBuilder.getRetrofit().create(ReIssue.class);
+        Utils.init(MyApp.getContext());
+        String at = Utils.getAccessToken("none");
+        String rt = Utils.getRefreshToken("nein");
+
+        Request original = chain.request().newBuilder().header("Authorization", "Bearer " + at).build();
+        Response response = chain.proceed(original);
+
+        if (response.code() == 401) {
+
+                TokenRequestDto tokenRequestDto = new TokenRequestDto(at, rt);
+                retrofit2.Response<TokenDto> token = reIssue.getReIssue(tokenRequestDto).execute();
+                if (token.isSuccessful()) {
+                    Utils.setAccessToken(token.body().getAccessToken());
+                    Utils.setRefreshToken(token.body().getRefreshToken());
+//                    Log.e("Interceptor", "At:" + Utils.getAccessToken("nein"));
+                    return chain.proceed(original.newBuilder().header("Authorization", "Bearer " + token.body().getAccessToken()).build());
+                }
+
+
+                return chain.proceed(original.newBuilder().header("Authorization", "Bearer " + Utils.getAccessToken("nein")).build());
+
+
+
+
+        }
+//        Log.e("Code What?", String.valueOf(response.code()));
+        return response;
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/Util/Utils.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/Util/Utils.java
@@ -1,0 +1,46 @@
+package com.example.fitin_v1.Util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class Utils {
+    private static final String PREFS = "prefs";
+    private static final String Access_Token = "Access_Token";
+    private static final String Refresh_Token = "Refresh_Token";
+    private Context mContext;
+    private static SharedPreferences prefs;
+    private static SharedPreferences.Editor prefsEditor;
+    private static Utils instance;
+
+    public static synchronized Utils init(Context context) {
+        if(instance == null)
+            instance = new Utils(context);
+        return instance;
+    }
+
+    private Utils(Context context) {
+        mContext = context;
+        prefs = mContext.getSharedPreferences(PREFS,Context.MODE_PRIVATE);
+        prefsEditor = prefs.edit();
+    }
+
+    public static void setAccessToken(String value) {
+        prefsEditor.putString(Access_Token, value).commit();
+    }
+
+    public static String getAccessToken(String defValue) {
+        return prefs.getString(Access_Token,defValue);
+    }
+
+    public static void setRefreshToken(String value) {
+        prefsEditor.putString(Refresh_Token, value).commit();
+    }
+
+    public static String getRefreshToken(String defValue) {
+        return prefs.getString(Refresh_Token,defValue);
+    }
+
+    public static void clearToken() {
+        prefsEditor.clear().apply();
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountLoginDto.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountLoginDto.java
@@ -1,0 +1,16 @@
+package com.example.fitin_v1.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AccountLoginDto {
+    @SerializedName("email")
+    private String email;
+
+    @SerializedName("password")
+    private String password;
+
+    public AccountLoginDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountRequestDto.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.fitin_v1.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AccountRequestDto {
+
+    @SerializedName("email")
+    private String email;
+
+    @SerializedName("password")
+    private String password;
+
+    @SerializedName("name")
+    private String name;
+
+    public AccountRequestDto(String email, String password, String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountResponseDto.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/AccountResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.fitin_v1.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AccountResponseDto {
+
+    @SerializedName("email")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/TokenDto.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/TokenDto.java
@@ -1,0 +1,18 @@
+package com.example.fitin_v1.dto;
+
+public class TokenDto {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/TokenRequestDto.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/dto/TokenRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.fitin_v1.dto;
+
+public class TokenRequestDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+
+    public TokenRequestDto(String access, String refresh) {
+        this.accessToken = access;
+        this.refreshToken = refresh;
+    }
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/GetAccount.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/GetAccount.java
@@ -1,0 +1,13 @@
+package com.example.fitin_v1.remote.api;
+
+import com.example.fitin_v1.dto.AccountResponseDto;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+
+public interface GetAccount {
+
+    @GET("/member/me")
+    Call<AccountResponseDto> getEmail(@Header("Authorization") String accessToken);
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/ReIssue.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/ReIssue.java
@@ -1,0 +1,14 @@
+package com.example.fitin_v1.remote.api;
+
+import com.example.fitin_v1.dto.TokenDto;
+import com.example.fitin_v1.dto.TokenRequestDto;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public interface ReIssue {
+
+    @POST("/auth/reissue")
+    Call<TokenDto> getReIssue(@Body TokenRequestDto tokenRequestDto);
+}

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/SignUp.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/SignUp.java
@@ -1,5 +1,8 @@
 package com.example.fitin_v1.remote.api;
 
+import com.example.fitin_v1.dto.AccountRequestDto;
+import com.example.fitin_v1.dto.AccountResponseDto;
+
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/SingIn.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/api/SingIn.java
@@ -1,5 +1,8 @@
 package com.example.fitin_v1.remote.api;
 
+import com.example.fitin_v1.dto.AccountLoginDto;
+import com.example.fitin_v1.dto.TokenDto;
+
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.POST;

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/singleton/RetrofitBuilder.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/remote/singleton/RetrofitBuilder.java
@@ -1,19 +1,42 @@
 package com.example.fitin_v1.remote.singleton;
 
-import com.example.fitin_v1.remote.api.SignUp;
 
+import androidx.annotation.NonNull;
+
+import com.example.fitin_v1.Util.AuthInterceptor;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class RetrofitBuilder {
 
+
+
     // 기본 Retrofit 세팅 기준 URL을 가지고
     public static Retrofit getRetrofit() {
+        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(interceptor)
+                .addInterceptor(new AuthInterceptor())
+                .build();
+
         return new Retrofit.Builder()
                 .baseUrl("http://10.0.2.2:8080")
+                .client(client)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
     }
 
 
+
+
 }
+

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/ui/login/LoginActivity.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/ui/login/LoginActivity.java
@@ -1,8 +1,6 @@
 package com.example.fitin_v1.ui.login;
 
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
@@ -11,21 +9,19 @@ import android.text.style.StyleSpan;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.example.fitin_v1.remote.api.AccountLoginDto;
-import com.example.fitin_v1.remote.api.AccountRequestDto;
+import com.example.fitin_v1.HomeActivity;
+import com.example.fitin_v1.Util.Utils;
+import com.example.fitin_v1.dto.AccountLoginDto;
 import com.example.fitin_v1.remote.api.SingIn;
-import com.example.fitin_v1.remote.api.TokenDto;
+import com.example.fitin_v1.dto.TokenDto;
 import com.example.fitin_v1.remote.singleton.RetrofitBuilder;
-import com.example.fitin_v1.ui.complete.CompleteActivity;
 import com.example.fitin_v1.ui.main.MainActivity;
 import com.example.fitin_v1.WebviewActivity;
 import com.example.fitin_v1.databinding.ActivityLoginBinding;
 import com.example.fitin_v1.ui.findid.FindIdActivity;
-import com.example.fitin_v1.ui.register.RegisterFirstActivity;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -38,12 +34,15 @@ public class LoginActivity extends AppCompatActivity {
     private String email;
     private String password;
 
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
         setTitle("로그인");
+
+        Utils.init(getApplicationContext());
 
         SingIn signIn = RetrofitBuilder.getRetrofit().create(SingIn.class);
 
@@ -73,16 +72,13 @@ public class LoginActivity extends AppCompatActivity {
                     public void onResponse(Call<TokenDto> call, Response<TokenDto> response) {
                         if (!response.isSuccessful()) {
                             Log.e("연결이 비정상적 : ", "error code : " + response.code());
-                            return;
                         } else {
-                            Log.e("액세스 토큰 ", response.body().getAccessToken());
-                            Log.e("리프레시 토큰 ", response.body().getRefreshToken());
-                            SharedPreferences prefs = getSharedPreferences("pref_name", Context.MODE_PRIVATE);
-                            prefs.edit().putString("Access Token",response.body().getAccessToken());
-                            prefs.edit().putString("Refresh Token", response.body().getRefreshToken());
-                            prefs.edit().commit();
-                            Toast.makeText(getApplicationContext(),"AT: " + prefs.getString("Access Token",""),Toast.LENGTH_LONG).show();
-                            Toast.makeText(getApplicationContext(),"RT: " + prefs.getString("Refresh Token", ""),Toast.LENGTH_LONG).show();
+                            Utils.setAccessToken(response.body().getAccessToken());
+                            Utils.setRefreshToken(response.body().getRefreshToken());
+//                            Log.e("Login", "at : " + Utils.getAccessToken("nein"));
+//                            Log.e("Login", "rt : " + Utils.getRefreshToken("none"));
+//                            // 인텐트 처리해서 Home으로 넘겨서 보내주면 될 듯(현재 테스트에선)
+                            // 만약 그게 아니면 굳이 인텐트 처리 안해줘도 됨, 어차피 저장되니깐
                         }
                     }
 
@@ -91,6 +87,10 @@ public class LoginActivity extends AppCompatActivity {
 
                     }
                 });
+
+                Intent intentHome = new Intent(getApplicationContext(), HomeActivity.class);
+                startActivity(intentHome);
+                finish();
             }
         });
 

--- a/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/ui/register/RegisterFirstActivity.java
+++ b/Android/FitIn_v1/app/src/main/java/com/example/fitin_v1/ui/register/RegisterFirstActivity.java
@@ -4,12 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.example.fitin_v1.remote.api.AccountRequestDto;
-import com.example.fitin_v1.remote.api.AccountResponseDto;
+import com.example.fitin_v1.dto.AccountRequestDto;
+import com.example.fitin_v1.dto.AccountResponseDto;
 import com.example.fitin_v1.remote.api.SignUp;
 import com.example.fitin_v1.remote.singleton.RetrofitBuilder;
 import com.example.fitin_v1.ui.login.LoginActivity;

--- a/Android/FitIn_v1/app/src/main/res/layout/activity_home.xml
+++ b/Android/FitIn_v1/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".HomeActivity">
+
+    <TextView
+        android:id="@+id/tv_email"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <Button
+        android:id="@+id/btn_reissue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="재발급"
+        app:layout_constraintTop_toTopOf="@id/btn_logout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_logout"
+        app:layout_constraintBottom_toBottomOf="@id/btn_logout"/>
+
+    <Button
+        android:id="@+id/btn_logout"
+        android:text="로그아웃"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/tv_email"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_reissue"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <Button
+        android:id="@+id/btn_getinfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="이메일 불러오기"
+        app:layout_constraintTop_toBottomOf="@id/btn_logout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_clear"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <Button
+        android:id="@+id/btn_clear"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="초기화"
+        app:layout_constraintTop_toTopOf="@id/btn_getinfo"
+        app:layout_constraintStart_toEndOf="@id/btn_getinfo"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/btn_getinfo"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/FitIn_v1/app/src/main/res/values/strings.xml
+++ b/Android/FitIn_v1/app/src/main/res/values/strings.xml
@@ -25,7 +25,6 @@
     <string name="clause_4">마케팅 정보 수신 동의(선택)</string>
 
 
-
     <string name="login_email_hint">이메일을 입력해주세요.</string>
     <string name="login_password_hint">비밀번호를 입력해주세요.</string>
     <string name="login_autologin_text">자동 로그인</string>
@@ -46,7 +45,6 @@
     <string name="find_id_complete_text">당신의 FITIN 아이디는\nXXXXXX입니다</string>
 
     <string name="find_pw_complete_text">비밀번호가 변경되었습니다\n다시 로그인 해주세요</string>
-
 
 
 </resources>


### PR DESCRIPTION
- JWT 토큰 통신 및 저장 방식 완료

- 테스트 방법
- 해당 값을 직접 보고 싶다면 주석처리한 로그를 다 풀고 보면 됨

   - 테스트 계정으로 회원가입 먼저 함

   - 해당 계정으로 로그인 함(이때 로그(Logcat error로 설정하고)에 토큰값이 나오는지 확인)

   - 재발급 버튼을 누르면 현재 저장된 토큰값 기준으로 재발급 통신을 함

   - 로그아웃 버튼 누르면 SharedPreferences로 저장된 토큰 값이 삭제됨(이때 재발급이나, 이메일 불러오기 하면 안됨, 토큰 값을 날렸으므로)

   - 이메일 불러오기 버튼 누르면 SharedPreferences에 저장된 토큰값을 가지고 GET 통신을 함, 추가로 서버에서 토큰 만료시간을 1분으로 만들고 1분 뒤에 이메일 불러오기 버튼 눌러보기를 바람, 이때 401에러이므로 Interceptor에서 재발급 통신을 해서 토큰을 갱신함(AuthInterceptor 확인)

- 위의 테스트 결과 토큰이 SharedPreferences에 잘 저장되고 삭제되면서 SharedPreferences를 통한 토큰 처리는 해결함

- 그리고 Interceptor를 통해서 Access Token 만료시 401 에러가 발생하는데 이 에러가 발생할 때 토큰을 재발급해서 갱신하는 로직을 만들어서 처리함