### PR TITLE
HDA-39 Interceptor 관련 Authenticator로 변경

### DIFF
--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/local/EncryptedSharedPreferenceController.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/local/EncryptedSharedPreferenceController.kt
@@ -6,25 +6,27 @@ import javax.inject.Inject
 
 class EncryptedSharedPreferenceController @Inject constructor(private val preferences: SharedPreferences) {
 
+    private val prefsEdit: SharedPreferences.Editor = preferences.edit()
+
     companion object {
         private val fitinAccessToken = PreferencesKey.provideAccessToken()
         private val fitinRefreshToken = PreferencesKey.provideRefreshToken()
     }
 
     fun setAccessToken(accessToken: String) {
-        preferences.edit().putString(fitinAccessToken, accessToken).apply()
+        prefsEdit.putString(fitinAccessToken, accessToken).apply()
     }
 
     fun getAccessToken(): String? = preferences.getString(fitinAccessToken, "no")
 
     fun setRefreshToken(refreshToken: String) {
-        preferences.edit().putString(fitinRefreshToken, refreshToken).apply()
+        prefsEdit.putString(fitinRefreshToken, refreshToken).apply()
     }
 
     fun getRefreshToken(): String? = preferences.getString(fitinRefreshToken, "no")
 
     fun deleteToken() {
-        preferences.edit().remove(fitinAccessToken).remove(fitinRefreshToken).apply()
+        prefsEdit.remove(fitinAccessToken).remove(fitinRefreshToken).commit()
     }
 
 }

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/remote/api/UserService.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/remote/api/UserService.kt
@@ -26,9 +26,9 @@ interface UserService {
     ): Response<ResponseToken>
 
     @POST("/auth/reissue")
-    suspend fun getReIssue(
+    fun getReIssue(
         @Body body: RequestTokenReissue
-    ): Response <ResponseToken>
+    ): Call<ResponseToken>
 
     @POST("/auth/logout")
     suspend fun postSignOut(

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/repository/UserRepository.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/data/repository/UserRepository.kt
@@ -15,7 +15,7 @@ class UserRepository @Inject constructor(private val userService: UserService){
 
     suspend fun postSignIn(requestSignIn: RequestSignIn) = userService.postSignIn(requestSignIn)
 
-    suspend fun postReIssue(requestTokenReissue: RequestTokenReissue) = withContext(Dispatchers.IO) {userService.getReIssue(requestTokenReissue) }
+    fun postReIssue(requestTokenReissue: RequestTokenReissue) = userService.getReIssue(requestTokenReissue)
 
     suspend fun getEmail(accessToken: String) = userService.getEmail("Bearer $accessToken")
 

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/di/NetworkModule.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/di/NetworkModule.kt
@@ -3,16 +3,22 @@ package com.example.fitin_kotlin.di
 import com.example.fitin_kotlin.data.local.EncryptedSharedPreferenceController
 import com.example.fitin_kotlin.data.remote.api.UserService
 import com.example.fitin_kotlin.data.repository.UserRepository
-import com.example.fitin_kotlin.network.AuthInterceptor
+//import com.example.fitin_kotlin.network.AuthInterceptor
+//import com.example.fitin_kotlin.network.AuthInterceptor
+//import com.example.fitin_kotlin.network.AuthInterceptor
+import com.example.fitin_kotlin.network.TokenAuthenticator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
 import okhttp3.OkHttp
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -29,11 +35,11 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun providesOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor, authInterceptor: AuthInterceptor): OkHttpClient =
+    fun providesOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor, tokenAuthenticator: TokenAuthenticator): OkHttpClient =
         OkHttpClient
             .Builder()
+            .authenticator(tokenAuthenticator)
             .addInterceptor(httpLoggingInterceptor)
-            .addInterceptor(authInterceptor)
             .build()
 
     @Singleton

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/network/AuthInterceptor.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/network/AuthInterceptor.kt
@@ -19,32 +19,43 @@ import javax.inject.Singleton
 //@Retention(AnnotationRetention.BINARY)
 //annotation class AuthInterceptorOkHttpClient
 
-@Singleton
-class AuthInterceptor @Inject constructor(private val prefs: EncryptedSharedPreferenceController, private val repository: Lazy<UserRepository>) : Interceptor{
-    override fun intercept(chain: Interceptor.Chain): Response {
+//@Singleton
+//class AuthInterceptor @Inject constructor(private val prefs: EncryptedSharedPreferenceController, private val repository: Lazy<UserRepository>) : Interceptor{
+//    override fun intercept(chain: Interceptor.Chain): Response {
+//
+//        val accessToken: String? = prefs.getAccessToken()
+//        val refreshToken: String? = prefs.getRefreshToken()
+//
+//        val original: Request = chain.request().newBuilder().header("Authorization",
+//            "Bearer $accessToken"
+//        ).build()
+//        var response: Response = chain.proceed(original)
+//
+//        if (response.code == 401 && response.body!!.equals("null")) {
+//            runBlocking {
+//                val requestTokenReissue = RequestTokenReissue(accessToken.toString(), refreshToken.toString())
+//                val token: retrofit2.Response<ResponseToken> = repository.get().postReIssue(requestTokenReissue)
+//                withContext(Dispatchers.Main) {
+//                    if(token.isSuccessful) {
+//                        prefs.setAccessToken(token.body()!!.accessToken)
+//                        prefs.setRefreshToken(token.body()!!.refreshToken)
+//                        response = chain.proceed(original.newBuilder().header("Authorization", "Bearer " + token.body()!!.accessToken).build())
+//                    }
+//                    response = chain.proceed(original.newBuilder().header("Authorization", "Bearer " + prefs.getAccessToken()).build())
+//                }
+//            }
+//        }
+//        return response
+//    }
+//}
 
-        val accessToken: String? = prefs.getAccessToken()
-        val refreshToken: String? = prefs.getRefreshToken()
-
-        val original: Request = chain.request().newBuilder().header("Authorization",
-            "Bearer $accessToken"
-        ).build()
-        var response: Response = chain.proceed(original)
-
-        if (response.code == 401 && response.body!!.equals("null")) {
-            runBlocking {
-                val requestTokenReissue = RequestTokenReissue(accessToken.toString(), refreshToken.toString())
-                val token: retrofit2.Response<ResponseToken> = repository.get().postReIssue(requestTokenReissue)
-                withContext(Dispatchers.Main) {
-                    if(token.isSuccessful) {
-                        prefs.setAccessToken(token.body()!!.accessToken)
-                        prefs.setRefreshToken(token.body()!!.refreshToken)
-                        response = chain.proceed(original.newBuilder().header("Authorization", "Bearer " + token.body()!!.accessToken).build())
-                    }
-                    response = chain.proceed(original.newBuilder().header("Authorization", "Bearer " + prefs.getAccessToken()).build())
-                }
-            }
-        }
-        return response
-    }
-}
+//class AuthInterceptor @Inject constructor(private val prefs:EncryptedSharedPreferenceController) : Interceptor {
+//    override fun intercept(chain: Interceptor.Chain): Response {
+//        val request: Request = chain.request()
+//            .newBuilder()
+//            .addHeader("Authorization", "Bearer ${prefs.getAccessToken()}")
+//            .build()
+//        return chain.proceed(request)
+//    }
+//
+//}

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/network/TokenAuthenticator.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/network/TokenAuthenticator.kt
@@ -1,0 +1,77 @@
+package com.example.fitin_kotlin.network
+
+import android.util.Log
+import com.example.fitin_kotlin.data.local.EncryptedSharedPreferenceController
+import com.example.fitin_kotlin.data.model.network.request.RequestTokenReissue
+import com.example.fitin_kotlin.data.model.network.response.ResponseToken
+import com.example.fitin_kotlin.data.repository.UserRepository
+import dagger.Lazy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+@Singleton
+class TokenAuthenticator @Inject constructor(
+    private val prefs: EncryptedSharedPreferenceController,
+    private val repository: Lazy<UserRepository>
+) : Authenticator {
+//
+//    val accessToken: String? = prefs.getAccessToken()
+//    val refreshToken: String? = prefs.getRefreshToken()
+
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+
+        if (response.responseCount >= 2) {
+            return null
+        }
+
+//        val accessToken: String? = prefs.getAccessToken()
+//        val refreshToken: String? = prefs.getRefreshToken()
+
+
+        val requestTokenReissue =
+            RequestTokenReissue(
+                prefs.getAccessToken().toString(),
+                prefs.getRefreshToken().toString()
+            )
+        val token: retrofit2.Response<ResponseToken> =
+            repository.get().postReIssue(requestTokenReissue).execute()
+        if (token.isSuccessful) {
+
+            prefs.setAccessToken(token.body()!!.accessToken)
+            prefs.setRefreshToken(token.body()!!.refreshToken)
+
+            Log.e("Token", "token ${prefs.getAccessToken().toString()}")
+
+            return response.request.newBuilder()
+                .header("Authorization", "Bearer ${token.body()?.accessToken}")
+                .build()
+        } else {
+            return null
+        }
+
+        return null
+
+
+
+//        if (accessToken != null) {
+//            return response.request.newBuilder()
+//                .header("Authorization", "Bearer ${accessToken}")
+//                .build()
+//        } else return null
+    }
+
+    private val Response.responseCount: Int
+        get() = generateSequence(this) { it.priorResponse }.count()
+
+}
+
+

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/ui/home/HomeViewModel.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/ui/home/HomeViewModel.kt
@@ -14,22 +14,20 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val userRepository: UserRepository,
-    prefs: EncryptedSharedPreferenceController
+    private val prefs: EncryptedSharedPreferenceController
 ) : ViewModel(){
 
-    val accessToken: MutableLiveData<String> = MutableLiveData<String>()
+//    val accessToken: MutableLiveData<String> = MutableLiveData<String>()
 
-    init {
-        accessToken.value = prefs.getAccessToken()
-    }
 
     fun onGetEmail(view: View) {
-        val token = accessToken.value.toString()
         viewModelScope.launch {
+            val token = prefs.getAccessToken().toString()
             val email = userRepository.getEmail(token)
             when (email.isSuccessful) {
                 true -> {
                     Log.e("email", "성공: " + email.body()?.email)
+                    Log.e("Token", "tokens ${token}")
                 }
                 else -> {
                     Log.e("실패", "error: " + email.message())


### PR DESCRIPTION
- 기존에 401 에러 처리에 있어서 Interceptor를 통해서 재발급 API 호출을 하였지만 response를 가져와서 체크하는데 있어서 살짝의 시간이 소요되서 근본적으로 전환을 함

- Authenticator를 활용, 401 에러가 발생할 경우 자동으로 인식을 하여서 재발급 호출 처리해서 Header를 바꿈

- 그 외에 구체적인 로그인 & 회원가입 모든 경우의 수 시나리오를 고려해서 예외처리 및 UI적으로 처리할 필요가 있어보임