### PR TITLE
HDA-46 로그인 실패 예외 처리 추가

### DIFF
--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/di/NetworkModule.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/di/NetworkModule.kt
@@ -40,7 +40,7 @@ object NetworkModule {
     fun providesOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor, tokenAuthenticator: TokenAuthenticator): OkHttpClient =
         OkHttpClient
             .Builder()
-            .authenticator(tokenAuthenticator)
+//            .authenticator(tokenAuthenticator)
             .addInterceptor(httpLoggingInterceptor)
             .build()
 

--- a/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/ui/onboard/signin/SignInViewModel.kt
+++ b/Android/FitIn_Kotlin/app/src/main/java/com/example/fitin_kotlin/ui/onboard/signin/SignInViewModel.kt
@@ -65,6 +65,9 @@ class SignInViewModel @Inject constructor(
                 }
                 else -> {
 //                    Log.e("실패", "error " + signIn.message())
+                    if (signIn.code() == 401) {
+                        _errorMessage.value = "비밀번호가 일치하지 않습니다."
+                    }
                     _eventSignIn.value = false
                 }
             }


### PR DESCRIPTION
### 작업사항
- 로그인 실패시 이를 401에러로 인식 토큰 만료와 동일하게 처리하는데 일단 Interceptor를 제외, 로그인 네트워크 처리 실패시에 팝업 메시지 띄우게 변경함

### 추후 적용사항
- 토큰 만료에 대해서 401에러인데 이 부분 재발급 처리에 대해서 좀 더 조사가 필요